### PR TITLE
Better development using Cerbero

### DIFF
--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -387,11 +387,14 @@ class CookBook (object):
     def _load_recipe_from_file(self, filepath, custom=None):
         mod_name, file_ext = os.path.splitext(os.path.split(filepath)[-1])
         if self._config.target_arch == Architecture.UNIVERSAL:
+            configs = self._config.arch_config.values()
             if self._config.target_platform in [Platform.IOS, Platform.DARWIN]:
                 recipe = crecipe.UniversalFlatRecipe(self._config)
             else:
                 recipe = crecipe.UniversalRecipe(self._config)
-        for c in self._config.arch_config.keys():
+        else:
+            configs = [self._config]
+        for config in configs:
             try:
                 d = {'Platform': Platform, 'Architecture': Architecture,
                      'BuildType': BuildType, 'SourceType': SourceType,
@@ -402,14 +405,14 @@ class CookBook (object):
                      'FatalError': FatalError,
                      'custom': custom, '_': _, 'shell': shell}
                 parse_file(filepath, d)
-                conf = self._config.arch_config[c]
                 if self._config.target_arch == Architecture.UNIVERSAL:
                     if self._config.target_platform not in [Platform.IOS,
                             Platform.DARWIN]:
-                        conf.prefix = os.path.join(self._config.prefix, c)
-                r = d['Recipe'](conf)
+                        config.prefix = os.path.join(self._config.prefix,
+                                config.target_arch)
+                r = d['Recipe'](config)
                 r.__file__ = os.path.abspath(filepath)
-                self._config.arch_config[c].do_setup_env()
+                config.do_setup_env()
                 r.prepare()
                 if self._config.target_arch == Architecture.UNIVERSAL:
                     recipe.add_recipe(r)

--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -275,7 +275,7 @@ class CookBook (object):
 
     def _cache_file(self, config):
         if config.cache_file is not None:
-            return os.path.join(config.home_dir, config.cache_file)
+            return os.path.join(config.work_dir, config.cache_file)
         else:
             return COOKBOOK_FILE
 

--- a/cerbero/build/source.py
+++ b/cerbero/build/source.py
@@ -231,6 +231,7 @@ class Git (GitCache):
         if not os.path.exists(self.build_dir):
             os.mkdir(self.build_dir)
 
+        m.action(_("Extracting to %s") % self.build_dir)
         # checkout the current version
         git.local_checkout(self.build_dir, self.repo_dir, self.commit)
 

--- a/cerbero/commands/wipe.py
+++ b/cerbero/commands/wipe.py
@@ -44,7 +44,7 @@ class Wipe(Command):
                 ])
 
     def run(self, config, args):
-        to_remove = [os.path.join(config.home_dir, config.cache_file)]
+        to_remove = [os.path.join(config.work_dir, config.cache_file)]
         to_remove.append(config.prefix)
         to_remove.append(config.logs)
         if not args.keep_sources:

--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -94,7 +94,7 @@ class Config (object):
                    'ios_platform', 'extra_build_tools',
                    'distro_packages_install', 'interactive',
                    'target_arch_flags', 'sysroot', 'isysroot',
-                   'extra_lib_path']
+                   'extra_lib_path', 'cerbero_branch']
 
     def __init__(self):
         self._check_uninstalled()
@@ -336,6 +336,7 @@ class Config (object):
         self.set_property('extra_build_tools', {})
         self.set_property('distro_packages_install', True)
         self.set_property('interactive', True)
+        self.set_property('cerbero_branch', self._cerbero_branch())
 
     def set_property(self, name, value, force=False):
         if name not in self._properties:

--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -436,7 +436,7 @@ class Config (object):
 
     def _load_main_config(self):
         if os.path.exists(DEFAULT_CONFIG_FILE):
-            self._parse(DEFAULT_CONFIG_FILE)
+            self._parse(DEFAULT_CONFIG_FILE, reset=False)
         else:
             msg = _('Using default configuration because %s is missing') % \
                 DEFAULT_CONFIG_FILE

--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -102,7 +102,7 @@ class Config (object):
         for a in self._properties:
             setattr(self, a, None)
 
-        self.arch_config = {self.target_arch: self}
+        self.arch_config = {}
         # Store raw os.environ data
         self._raw_environ = os.environ.copy()
         self._pre_environ = os.environ.copy()
@@ -167,6 +167,10 @@ class Config (object):
         self._migrate_work_dir_if_needed()
 
         self.do_setup_env()
+
+        self._create_path(self.local_sources)
+        self._create_path(self.sources)
+        self._create_path(self.logs)
 
         # Store current os.environ data
         for c in self.arch_config.values():

--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -94,7 +94,7 @@ class Config (object):
                    'ios_platform', 'extra_build_tools',
                    'distro_packages_install', 'interactive',
                    'target_arch_flags', 'sysroot', 'isysroot',
-                   'extra_lib_path', 'cerbero_branch']
+                   'extra_lib_path', 'cerbero_branch', 'fetch_resets_repository']
 
     def __init__(self):
         self._check_uninstalled()
@@ -336,6 +336,7 @@ class Config (object):
         self.set_property('extra_build_tools', {})
         self.set_property('distro_packages_install', True)
         self.set_property('interactive', True)
+        self.set_property('fetch_resets_repository', False)
         self.set_property('cerbero_branch', self._cerbero_branch())
 
     def set_property(self, name, value, force=False):

--- a/cerbero/packages/debian.py
+++ b/cerbero/packages/debian.py
@@ -191,7 +191,7 @@ class DebianPackager(LinuxPackager):
     def create_tree(self, tmpdir):
         # create a tmp dir to use as topdir
         if tmpdir is None:
-            tmpdir = tempfile.mkdtemp(dir=self.config.home_dir)
+            tmpdir = tempfile.mkdtemp(dir=self.config.work_dir)
         srcdir = os.path.join(tmpdir, self.full_package_name)
         os.mkdir(srcdir)
         packagedir = os.path.join(srcdir, 'debian')

--- a/cerbero/packages/rpm.py
+++ b/cerbero/packages/rpm.py
@@ -148,7 +148,7 @@ class RPMPackager(LinuxPackager):
     def create_tree(self, tmpdir):
         # create a tmp dir to use as topdir
         if tmpdir is None:
-            tmpdir = tempfile.mkdtemp(dir=self.config.home_dir)
+            tmpdir = tempfile.mkdtemp(dir=self.config.work_dir)
             for d in ['BUILD', 'SOURCES', 'RPMS', 'SRPMS', 'SPECS']:
                 os.mkdir(os.path.join(tmpdir, d))
         return (tmpdir, os.path.join(tmpdir, 'RPMS'),

--- a/cerbero/utils/git.py
+++ b/cerbero/utils/git.py
@@ -147,6 +147,16 @@ def get_hash(git_dir, commit):
                             (GIT, commit), git_dir, env=CLEAN_ENV)
 
 
+def get_checkout_branch(git_dir):
+    '''
+    Get the current branch name.
+
+    @param git:dir: path to the git repository
+    @type git_dir: str
+    '''
+    return shell.check_call('%s rev-parse --abbrev-ref HEAD' % GIT,
+            git_dir).strip()
+
 def local_checkout(git_dir, local_git_dir, commit):
     '''
     Clone a repository for a given commit in a different location

--- a/cerbero/utils/git.py
+++ b/cerbero/utils/git.py
@@ -161,18 +161,12 @@ def local_checkout(git_dir, local_git_dir, commit):
     # reset to a commit in case it's the first checkout and the masterbranch is
     # missing
     branch_name = 'cerbero_build'
-    shell.call('%s reset --hard %s' % (GIT, commit), local_git_dir,
+    shell.call('%s clone -s --no-checkout %s .' % (GIT, local_git_dir), git_dir,
                env=CLEAN_ENV)
-    shell.call('%s branch %s' % (GIT, branch_name), local_git_dir, fail=False,
+    shell.call('%s fetch origin refs/remotes/*:refs/remotes/*' % GIT, git_dir,
                env=CLEAN_ENV)
-    shell.call('%s checkout %s' % (GIT, branch_name), local_git_dir,
+    shell.call('%s checkout -B %s %s' % (GIT, branch_name, commit), git_dir,
                env=CLEAN_ENV)
-    shell.call('%s reset --hard %s' % (GIT, commit), local_git_dir,
-               env=CLEAN_ENV)
-    return shell.call('%s clone %s -s -b %s .' % (GIT, local_git_dir,
-                                                  branch_name),
-                      git_dir, env=CLEAN_ENV)
-
 
 def add_remote(git_dir, name, url):
     '''

--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -152,11 +152,11 @@ def call(cmd, cmd_dir='.', fail=True, env=None):
                                        stderr=subprocess.STDOUT,
                                        stdout=StdOut(stream),
                                        env=env, shell=shell)
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError, e:
         if fail:
             raise FatalError(_("Error running command: %s") % cmd)
         else:
-            ret = 0
+            ret = e.returncode
     return ret
 
 


### PR DESCRIPTION
@alessandrod's patches from GstHackfest 2015 to improve the development workflow while using Cerbero. With these patches, you can hack in a git checkout in ~/cerbero/sources, and your commits will be used while building.

I'll leave it to @alessandrod to explain his changes better. :)
