### PR TITLE
libffi: set FFI_MMAP_EXEC_WRIT and unset FFI_MMAP_EXEC_SELINUX on Android

### DIFF
--- a/recipes/libffi.recipe
+++ b/recipes/libffi.recipe
@@ -56,6 +56,8 @@ class Recipe(recipe.Recipe):
 
             self.make = 'make -C %s' % dir
             self.make_install = 'make -C %s install' % dir
+        elif self.config.target_platform == Platform.ANDROID:
+            self.append_env['CFLAGS'] = ' -DFFI_MMAP_EXEC_WRIT=1 -DFFI_MMAP_EXEC_SELINUX=0 '
         else:
             self.files_devel.append(os.path.join(self.libffidir, 'include', 'ffitarget.h'))
 


### PR DESCRIPTION
This fixes a crash on Android
Found here: https://github.com/frida/frida/blob/d3679e46df36986beca03da59be7acd691b6babe/releng/config.site.in#L119 (thanks to @oleavr)
