### PR TITLE
debian: add shlibdeps parameter to ignore missing info

### DIFF
--- a/cerbero/packages/debian.py
+++ b/cerbero/packages/debian.py
@@ -157,7 +157,7 @@ binary-arch: build install
 	dh_fixperms -a
 	dh_makeshlibs -a -V
 	dh_installdeb -a
-	dh_shlibdeps -a
+	dh_shlibdeps -a --dpkg-shlibdeps-params=--ignore-missing-info
 	dh_gencontrol -a
 	dh_md5sums -a
 	dh_builddeb -a


### PR DESCRIPTION
While packaging openwebrtc, sometimes it fails because some of libraries
likelibjpeg, libpng16, libcairo are not provide package information.
The parameter,--dpkg-shlibdeps-params=--ignore-missing-info, helps make
packages.
