### PR TITLE
fixed gst-python at specific commit instead of master

### DIFF
--- a/recipes/gst-python-1.0.recipe
+++ b/recipes/gst-python-1.0.recipe
@@ -10,7 +10,7 @@ class Recipe(recipe.Recipe):
     autoreconf = True
     autoreconf_sh = 'sh autogen.sh'
     remotes = {'origin': 'git://anongit.freedesktop.org/gstreamer/gst-python'}
-    commit = 'origin/master'
+    commit = '7b627c499dcb63567ac890a3b793209c7413772a'
     deps = ['gstreamer-1.0', 'gst-plugins-base-1.0', 'glib', 'pygobject']
     # FIXME: disable checks until it's properly fixed
     make_check = None


### PR DESCRIPTION
fixed an issue with the build process, when gst-python requires a higher version of gstreamer. ( fixed gst-python to a specific commit instead of master)
