### PR TITLE
cerbero: add support for ubuntu/xenial

### DIFF
--- a/cerbero/enums.py
+++ b/cerbero/enums.py
@@ -77,6 +77,7 @@ class DistroVersion:
     UBUNTU_UTOPIC = 'ubuntu_utopic'
     UBUNTU_VIVID = 'ubuntu_vivid'
     UBUNTU_WILY = 'ubuntu_wily'
+    UBUNTU_XENIAL = 'ubuntu_xenial'
     FEDORA_16 = 'fedora_16'
     FEDORA_17 = 'fedora_17'
     FEDORA_18 = 'fedora_18'

--- a/cerbero/utils/__init__.py
+++ b/cerbero/utils/__init__.py
@@ -159,6 +159,8 @@ def system_info():
                 distro_version = DistroVersion.UBUNTU_VIVID
             elif d[2] in ['wily']:
                 distro_version = DistroVersion.UBUNTU_WILY
+            elif d[2] in ['xenial']:
+                distro_version = DistroVersion.UBUNTU_XENIAL
             elif d[1].startswith('6.'):
                 distro_version = DistroVersion.DEBIAN_SQUEEZE
             elif d[1].startswith('7.') or d[1].startswith('wheezy'):

--- a/recipes/glib.recipe
+++ b/recipes/glib.recipe
@@ -149,7 +149,8 @@ class Recipe(recipe.Recipe):
                                                        DistroVersion.UBUNTU_TRUSTY,
                                                        DistroVersion.UBUNTU_UTOPIC,
                                                        DistroVersion.UBUNTU_VIVID,
-                                                       DistroVersion.UBUNTU_WILY]:
+                                                       DistroVersion.UBUNTU_WILY,
+                                                       DistroVersion.UBUNTU_XENIAL]:
                 if self.config.target_arch == Architecture.X86:
                     path2 = '/usr/lib/i386-linux-gnu/gio/modules'
                 elif self.config.target_arch == Architecture.X86_64:

--- a/recipes/gtk+3.recipe
+++ b/recipes/gtk+3.recipe
@@ -124,7 +124,8 @@ class Recipe(recipe.Recipe):
                                                        DistroVersion.UBUNTU_TRUSTY,
                                                        DistroVersion.UBUNTU_UTOPIC,
                                                        DistroVersion.UBUNTU_VIVID,
-                                                       DistroVersion.UBUNTU_WILY]:
+                                                       DistroVersion.UBUNTU_WILY,
+                                                       DistroVersion.UBUNTU_XENIAL]:
                 if self.config.target_arch == Architecture.X86:
                     mod_path2 = '/usr/lib/i386-linux-gnu/gtk-3.0'
                 elif self.config.target_arch == Architecture.X86_64:


### PR DESCRIPTION
Successfully used this patch to build on Ubuntu 16.04. It's basically the same as 15.10.
