### PR TITLE
updated zlib and openssl recipe versions

### DIFF
--- a/recipes/openssl.recipe
+++ b/recipes/openssl.recipe
@@ -6,7 +6,7 @@ from cerbero.utils import shell, messages
 
 class Recipe(recipe.Recipe):
     name = 'openssl'
-    version = '1.0.2j'
+    version = '1.0.2k'
     licenses = [License.BSD_like]
     stype = SourceType.TARBALL
     url = 'ftp://ftp.openssl.org/source/{0}-{1}.tar.gz'.format(name, version)

--- a/recipes/zlib.recipe
+++ b/recipes/zlib.recipe
@@ -4,10 +4,10 @@ from cerbero.tools.libtool import LibtoolLibrary
 
 class Recipe(recipe.Recipe):
     name = 'zlib'
-    version = '1.2.10'
+    version = '1.2.11'
     stype = SourceType.TARBALL
     btype = BuildType.MAKEFILE
-    url = 'http://zlib.net/zlib-1.2.10.tar.xz'
+    url = 'http://zlib.net/zlib-1.2.11.tar.xz'
     licenses = [License.BSD_like]
     add_host_build_target = False
     can_use_configure_cache = False


### PR DESCRIPTION
This temporarily fixes https://github.com/EricssonResearch/openwebrtc/issues/682, but there should probably be a more permanent fix. This will break again once the zlib and openssl projects release new versions.