### PR TITLE
Updated the openssl version.

### DIFF
--- a/recipes/openssl.recipe
+++ b/recipes/openssl.recipe
@@ -6,7 +6,7 @@ from cerbero.utils import shell, messages
 
 class Recipe(recipe.Recipe):
     name = 'openssl'
-    version = '1.0.2l'
+    version = '1.0.2n'
     licenses = [License.BSD_like]
     stype = SourceType.TARBALL
     url = 'ftp://ftp.openssl.org/source/{0}-{1}.tar.gz'.format(name, version)


### PR DESCRIPTION
Updated the version of openssl from 1.0.2l to 1.0.2n. ftp://ftp.openssl.org/source/ does not provide openssl-1.0.2l.tar.gz but openssl-1.0.2n.tar.gz as of writing.