### PR TITLE
openssl version bump

### DIFF
--- a/recipes/openssl.recipe
+++ b/recipes/openssl.recipe
@@ -6,7 +6,7 @@ from cerbero.utils import shell, messages
 
 class Recipe(recipe.Recipe):
     name = 'openssl'
-    version = '1.0.2l'
+    version = '1.0.2n'
     licenses = [License.BSD_like]
     stype = SourceType.TARBALL
     url = 'ftp://ftp.openssl.org/source/{0}-{1}.tar.gz'.format(name, version)


### PR DESCRIPTION
As of 12/7/2017, `1.0.2n` is the currently available version of the 1.0.2 branch of OpenSSL at ftp://ftp.openssl.org/source/